### PR TITLE
Remove the duplicate data view

### DIFF
--- a/CVElk.sh
+++ b/CVElk.sh
@@ -6,17 +6,6 @@ sleep 45
 
 docker run --network=host nvdata
 
-curl -X POST "localhost:5601/api/data_views/data_view" -H 'kbn-xsrf: true' -H 'Content-Type: application/json' -d'
-{
-  "data_view": {
-    "title": "cves*",
-    "name": "CVE",
-    "timeFieldName": "published",
-    "runtimeFieldMap": "{}"
-    }
-}
-'
-
 curl -f -XPOST -H "Content-Type: application/json" -H "kbn-xsrf: kibana" \
         "http://localhost:5601/api/kibana/settings/theme:darkMode" \
         -d '{ "value": true}'


### PR DESCRIPTION
Right now you get two `CVE` data views: One created manually (removed in this PR) and the other one from the Dashboard import that's also adding its own. The command is necessary for bootstrapping without a dashboard though, so it could also make sense as a comment