### PR TITLE
fix: update vulnerable Python dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,13 @@ dependencies = [
     "typer>=0.12.0",
     "rich>=13.7.0",
     "anyio>=4.3.0",
+    # Transitive dependency pins for security (Dependabot alerts)
+    "Pillow>=10.3.0",
+    "certifi>=2023.7.22",
+    "urllib3>=2.5.0",
+    "requests>=2.32.4",
+    "fonttools>=4.60.2",
+    "idna>=3.7",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
Updates 6 Python packages to resolve 14 Dependabot alerts (1 critical, 5 high, 8 moderate).

Adds explicit minimum version constraints for transitive dependencies in `pyproject.toml` to prevent resolution to vulnerable versions.

## Changes
- Pillow >= 10.3.0
- certifi >= 2023.7.22
- urllib3 >= 2.5.0
- requests >= 2.32.4
- fonttools >= 4.60.2
- idna >= 3.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)