### PR TITLE
Harden container scan: bump base image, ignore unfixed CVEs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -65,6 +65,10 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
+          # Only report vulnerabilities that have a fix available. This drops the
+          # Debian base-image "won't fix" CVEs (apt, tar, util-linux, perl, etc.)
+          # that dominate the code-scanning results and can't be remediated here.
+          ignore-unfixed: true
 
       - name: Upload Trivy scan results
         uses: github/codeql-action/upload-sarif@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM python:3.11-slim as builder
+FROM python:3.12-slim as builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ COPY src/ ./src/
 RUN hatch build -t wheel
 
 # Runtime stage
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # Create non-root user
 RUN useradd --create-home --shell /bin/bash cvelk


### PR DESCRIPTION
Opened by github-security-triage.

The Trivy container scan currently uploads **every** Debian base-image CVE to code scanning. That's the bulk of the ~113 open code-scanning alerts (only ~54 unique, many duplicated across layers) — mostly won't-fix OS-package issues (`apt`, `tar`, `util-linux`, `perl`) that can't be remediated in this repo and bury the real findings.

Changes:
- **Base image** `python:3.11-slim` → `python:3.12-slim` for current patches (within the project's supported `>=3.11` range).
- **`ignore-unfixed: true`** on the Trivy step so only vulnerabilities with an available fix are reported. On the next scan, code scanning auto-closes the no-fix alerts, leaving the actionable ones.

After merge, trigger the Security workflow (or wait for the Monday cron) to let the alert list re-baseline.