### PR TITLE
Upgrade pip in runtime image to clear pip CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ RUN useradd --create-home --shell /bin/bash cvelk
 # Set working directory
 WORKDIR /app
 
+# Upgrade pip to clear known pip CVEs in the base image (Trivy flags pip 25.0.1)
+RUN pip install --no-cache-dir --upgrade pip
+
 # Install the wheel from builder stage
 COPY --from=builder /app/dist/*.whl ./
 RUN pip install --no-cache-dir ./*.whl && rm -f ./*.whl


### PR DESCRIPTION
Opened by github-security-triage.

After hardening the Trivy scan (#68), the 4 remaining code-scanning alerts are all the same root cause: the `python:3.12-slim` base ships `pip 25.0.1`, flagged for:
- CVE-2025-8869 (medium, fix 25.3)
- CVE-2026-3219 (medium, fix 26.1)
- CVE-2026-6357 (medium, fix 26.1)
- CVE-2026-1703 (low, fix 26.0)

Adds `pip install --upgrade pip` to the runtime stage so the scanned image ships a patched pip. Should take CVElk's code-scanning alerts to 0.