### PR TITLE
fix(security): clear Trivy alerts and CI build warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,21 @@ jobs:
 
       - name: Get version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          if [ "$EVENT_NAME" = "release" ]; then
+            version="${RELEASE_TAG#v}"
           else
-            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            version="${INPUT_VERSION#v}"
           fi
+          if ! printf '%s' "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.]+)?$'; then
+            echo "::error::Invalid version: $version"
+            exit 1
+          fi
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
-          languages: python
+          languages: python, actions
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
@@ -59,7 +59,7 @@ jobs:
         run: docker build -t cvelk:scan .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: 'cvelk:scan'
           format: 'sarif'
@@ -85,6 +85,6 @@ jobs:
           fetch-depth: 0
 
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@bcfcf73aaf4759d4dadc2783177c245a02792318 # v3.97.0
         with:
           extra_args: --only-verified

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 # Build stage
-FROM python:3.12-slim as builder
+FROM python:3.12-slim AS builder
 
 WORKDIR /app
+
+# pip runs as root inside the image on purpose; silence its venv nag
+ENV PIP_ROOT_USER_ACTION=ignore
 
 # Install build dependencies
 RUN pip install --no-cache-dir hatch
@@ -16,6 +19,8 @@ RUN hatch build -t wheel
 # Runtime stage
 FROM python:3.12-slim
 
+ENV PIP_ROOT_USER_ACTION=ignore
+
 # Upgrade OS packages to pick up security fixes (e.g. liblzma5 CVE-2026-34743)
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 
@@ -25,12 +30,15 @@ RUN useradd --create-home --shell /bin/bash cvelk
 # Set working directory
 WORKDIR /app
 
-# Upgrade pip to clear known pip CVEs in the base image (Trivy flags pip 25.0.1)
-RUN pip install --no-cache-dir --upgrade pip
-
-# Install the wheel from builder stage
+# Install the wheel from builder stage, then remove the installer toolchain.
+# Nothing in this image needs pip at run time, and pip ships vendored copies of
+# setuptools and msgpack (see pip/_vendor/vendor.txt) that Trivy reports as
+# CVE-2025-47273, CVE-2026-59890 and GHSA-6v7p-g79w-8964. Those pins are frozen
+# upstream, so removing pip is the only real remediation.
 COPY --from=builder /app/dist/*.whl ./
-RUN pip install --no-cache-dir ./*.whl && rm -f ./*.whl
+RUN pip install --no-cache-dir ./*.whl \
+    && rm -f ./*.whl \
+    && pip uninstall -y pip setuptools wheel
 
 # Create data directory
 RUN mkdir -p /app/data && chown cvelk:cvelk /app/data


### PR DESCRIPTION
## Summary

Clears all three open code-scanning alerts and the recurring build warnings on the Docker Build job.

## Root cause of the Trivy alerts

All three alerts pointed at packages that are **not** dependencies of `cvelk`. They came from pip's own vendored copies, listed in `pip/_vendor/vendor.txt`:

| Package | Version | Alert |
|---|---|---|
| `setuptools` | 70.3.0 | CVE-2025-47273 (high), CVE-2026-59890 (medium) |
| `msgpack` | 1.1.2 | GHSA-6v7p-g79w-8964 (high) |

pip 25.0.1, 25.3, and 26.2.1 all pin `setuptools==70.3.0`, and 25.3+ pins `msgpack==1.1.2`. So the previous `pip install --upgrade pip` step could never have fixed this, and it actually moved msgpack from 1.1.0 to the flagged 1.1.2. A dependency pin would not help either, since neither package appears anywhere in the resolved dependency tree.

The fix is to drop pip from the runtime image once the wheel is installed. Nothing in the image needs it: the entrypoint is the `cvelk` CLI, the healthcheck is a plain import, and no source file references pip or `pkg_resources`.

## Verification

Built locally for `linux/amd64` and scanned with the same flags the workflow uses:

- `docker run cvelk:scan --help` works, healthcheck command prints `2.0.0`
- No `pip` / `setuptools` / `msgpack` / `wheel` left in `site-packages`
- `trivy image --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed` reports **0 findings**
- Build emits **zero warnings**, down from 1 GitHub annotation plus 3 pip warnings

## Also in this PR

- **`AS builder`** instead of `as builder`. This was emitting a `FromAsCasing` warning annotation on every CI run.
- **`PIP_ROOT_USER_ACTION=ignore`**, clearing the "Running pip as the 'root' user" warnings from build logs.
- **SHA-pinned `trivy-action` and `trufflehog`.** They tracked `@master` and `@main`, which Dependabot cannot update despite `github-actions` being enabled in `dependabot.yml`. That also meant scan behavior could change with no commit in this repo. Both SHAs were dereferenced against the API to confirm they match the claimed tags.
- **Hardened the release version step.** Inputs now arrive via `env:` rather than being spliced into the shell script, the `v` prefix is normalized, and the version is validated before it flows into the container tags and the PyPI upload. Tested against releases, dispatch inputs, prereleases, malformed input, and an injection-shaped input.
- **Added `actions` to the CodeQL languages** so this class of workflow issue is caught automatically going forward.

## Notes for review

- `pypa/gh-action-pypi-publish@release/v1` was deliberately left unpinned. It is the ref PyPA documents, and pinning it means manually chasing their OIDC and trusted-publisher fixes.
- Enabling the `actions` CodeQL language will likely surface a batch of new alerts on first run, probably including one for that PyPI action. Expected, but it is triage that has not been done yet.
- The release workflow has never run (no tags or releases exist). The version-step changes are tested in isolation but not end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)