### PR TITLE
fix(ci): scope GITHUB_TOKEN to contents:read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# Every job here only reads the repo. Codecov runs tokenless (use_oidc: false)
+# and neither upload-artifact nor the gha build cache uses GITHUB_TOKEN.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

Closes the five `actions/missing-workflow-permissions` alerts (207-211) that appeared after #81 added the `actions` language to CodeQL.

`ci.yml` had no `permissions:` block at all, so its five jobs ran with the repository default, which is typically write access across most scopes. `security.yml` and `release.yml` already declared theirs; `ci.yml` was the gap. This is a pre-existing issue that CodeQL simply could not see before, not a regression from #81.

## Why `contents: read` is sufficient

All five jobs (`lint`, `type-check`, `test`, `build`, `docker`) only read the repo:

- **Codecov** uploads tokenless. The run log for `32266511937` shows `use_oidc: false`, so no `id-token: write` is required.
- **`upload-artifact`** uses the runtime token, not `GITHUB_TOKEN`.
- **`type=gha` build cache** likewise uses the runtime token.
- The `docker` job builds with `push: false`, so no registry write is involved.

Verified by parsing the workflow that all five jobs inherit the top-level block with no job-level overrides.

## Note

The remaining item I flagged in #81, the unpinned `pypa/gh-action-pypi-publish@release/v1`, did **not** produce an alert. CodeQL's actions pack does not flag it, so that stays a judgment call rather than something the scanner will nag about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)